### PR TITLE
fixed removing 'on_' prefix

### DIFF
--- a/bedrock/server.py
+++ b/bedrock/server.py
@@ -151,7 +151,7 @@ class Server:
     
     def _remove_prefix(self, string: str) -> str:
         output = string.removeprefix(self._prefix)
-        if len(output) != len(string):
+        if len(output) == len(string):
             raise ValueError(f"missing prefix {self._prefix!r}")
         return output
     


### PR DESCRIPTION
Seems like I used a wrong operator. Because I am currently
rewriting this library I will not publish a release with a patch
on PyPI.

# Fix this issue

```
pip uninstall bedrockpy &&
gh clone phoenixr-codes/bedrockpy -- --branch phoenixr-codes-patch-on-prefix &&
cd $_ &&
pip install .
```

# The issue

https://github.com/phoenixr-codes/bedrockpy/blob/bb87e7e472055b8b398a2f2a25e09d646dcdb5e7/bedrock/server.py#L154